### PR TITLE
Fixed a small typpo in the dropdown AzureOpenAI

### DIFF
--- a/DBChatPro/Components/Pages/Home.razor
+++ b/DBChatPro/Components/Pages/Home.razor
@@ -51,7 +51,7 @@
                                 Placeholder="Select AI Platform">
                                     @if (!string.IsNullOrEmpty(config.GetValue<string>("AZURE_OPENAI_ENDPOINT")))
                                     {
-                                        <MudSelectItem Value="@("Azure OpenAI")" T="string">Azure OpenAI</MudSelectItem>
+                                        <MudSelectItem Value="@("AzureOpenAI")" T="string">Azure OpenAI</MudSelectItem>
                                     }
                                     @if (!string.IsNullOrEmpty(config.GetValue<string>("OPENAI_KEY")))
                                     {


### PR DESCRIPTION
There was an extra space there which caused the switch to fail when AzureOpenAI was selected